### PR TITLE
#11 - built files cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 composer.lock
 .env
+.toolbox.cache

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "krzysztofrewak/openapi-merge": "^2.0"
   },
   "require-dev": {
-    "blumilksoftware/codestyle": "^2.2",
+    "blumilksoftware/codestyle": "^2.5",
     "phpunit/phpunit": "^10.1"
   },
   "autoload": {

--- a/config/openapi_toolbox.php
+++ b/config/openapi_toolbox.php
@@ -12,6 +12,11 @@ return [
         "index" => "openapi.yml",
         "allow_multiple_files" => false,
     ],
+    "cache" => [
+        "enabled" => false,
+        "documentation_path" => storage_path("framework/cache/openapi"),
+        "checksum_path" => storage_path("framework/cache/openapi.md5"),
+    ],
     "ui" => [
         "enabled" => false,
         "title" => "Documentation",

--- a/index.php
+++ b/index.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+//shell_exec('find ./src -name "*.php" -exec md5sum {} \; > .toolbox.cache');
+
+$files = shell_exec('md5sum -c .toolbox.cache 2>/dev/null');
+var_dump(count(array_filter(explode("\n", $files), fn(string $line): bool => str_ends_with($line, ": FAILED"))));

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,7 @@
+[![Packagist PHP Version Support](https://img.shields.io/packagist/php-v/blumilksoftware/openapi-toolbox?style=for-the-badge)](https://packagist.org/packages/blumilksoftware/openapi-toolbox)
+[![Packagist Version](https://img.shields.io/packagist/v/blumilksoftware/openapi-toolbox?style=for-the-badge)](https://packagist.org/packages/blumilksoftware/openapi-toolbox)
+[![Packagist Downloads](https://img.shields.io/packagist/dt/blumilksoftware/openapi-toolbox?style=for-the-badge)](https://packagist.org/packages/blumilksoftware/openapi-toolbox/stats)
+
 ## 🧰 openapi-toolbox
 
 OpenAPI Toolbox is a handy package with all important documentation-related features we are using in some of **[@blumilksoftware](https://github.com/blumilksoftware)** projects.
@@ -29,6 +33,11 @@ return [
         "path" => resource_path("openapi"),
         "index" => "openapi.yml",
         "allow_multiple_files" => false,
+    ],
+    "cache" => [
+        "enabled" => false,
+        "documentation_path" => storage_path("framework/cache/openapi"),
+        "checksum_path" => storage_path("framework/cache/openapi.md5"),
     ],
     "ui" => [
         "enabled" => false,
@@ -96,3 +105,5 @@ use \Blumilk\OpenApiToolbox\OpenApiCompatibility\OpenApiCompatibility;
 ```
 
 Every time any HTTP call to application would be performed during tests, additional validation will be performed and structure of requests and responses will be checked against OpenAPI specification. For special cases (e.g. testing invalid requests) this validation can be disabled by using `$this->withoutRequestValidation()` and `$this->withoutResponseValidation()`.  
+
+With configuration `openapi_toolbox.cache.enabled = true` internal builders will use cached OpenAPI specifications. 

--- a/src/OpenApiSpecification/DocumentationBuilders/CacheActions.php
+++ b/src/OpenApiSpecification/DocumentationBuilders/CacheActions.php
@@ -34,14 +34,7 @@ trait CacheActions
         $process = new Process(["md5sum", "-c", $path]);
         $process->run();
 
-        $md5checksum = $process->getOutput();
-
-        return count(
-            array_filter(
-                explode("\n", $md5checksum),
-                fn(string $line): bool => str_ends_with($line, ": FAILED"),
-            ),
-        ) === 0;
+        return $process->isSuccessful();
     }
 
     protected function getCachedDocumentation(): string
@@ -56,7 +49,7 @@ trait CacheActions
         $documentationPath = $this->config->get("openapi_toolbox.specification.path");
         $checksumPath = $this->config->get("openapi_toolbox.cache.checksum_path");
 
-        $process = new Process(["find", $documentationPath, "-type", "f", "-exec", "md5sum", "{}", "\;", ">", $checksumPath]);
+        $process = Process::fromShellCommandline("find $documentationPath -type f -exec md5sum {} \; > $checksumPath");
         $process->run();
     }
 }

--- a/src/OpenApiSpecification/DocumentationBuilders/CacheActions.php
+++ b/src/OpenApiSpecification/DocumentationBuilders/CacheActions.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blumilk\OpenApiToolbox\OpenApiSpecification\DocumentationBuilders;
+
+use Closure;
+
+trait CacheActions
+{
+    protected function cache(Closure $closure): string
+    {
+        if ($this->cachedDocumentationExists()) {
+            if ($this->cacheChecksumIsValid()) {
+                return $this->getCachedDocumentation();
+            }
+        }
+
+        $content = $closure->call();
+        $this->cacheDocumentation($content);
+
+        return $content;
+    }
+
+    protected function cachedDocumentationExists(): bool
+    {
+        return file_exists($this->config->get("openapi_toolbox.cache.documentation_path"));
+    }
+
+    protected function getCachedDocumentation(): string
+    {
+        return file_get_contents($this->config->get("openapi_toolbox.cache.documentation_path"));
+    }
+
+    protected function cacheChecksumIsValid(): bool
+    {
+        $md5checksum = file_get_contents($this->config->get("openapi_toolbox.cache.checksum_path"));
+
+        return count(
+            array_filter(
+                explode("\n", $md5checksum),
+                fn(string $line): bool => str_ends_with($line, ": FAILED"),
+            ),
+        ) === 0;
+    }
+
+    protected function cacheDocumentation(string $content): void
+    {
+        file_put_contents($this->config->get("openapi_toolbox.cache.documentation_path"), $content);
+
+        $documentationPath = $this->config->get("openapi_toolbox.specification.path");
+        $checksumPath = $this->config->get("openapi_toolbox.cache.checksum_path");
+        shell_exec("find $documentationPath -exec md5sum {} \; > $checksumPath");
+    }
+}

--- a/src/OpenApiSpecification/DocumentationBuilders/CacheActions.php
+++ b/src/OpenApiSpecification/DocumentationBuilders/CacheActions.php
@@ -16,7 +16,7 @@ trait CacheActions
             }
         }
 
-        $content = $closure->call();
+        $content = $closure->call($this);
         $this->cacheDocumentation($content);
 
         return $content;
@@ -24,7 +24,7 @@ trait CacheActions
 
     protected function cachedDocumentationExists(): bool
     {
-        return file_exists($this->config->get("openapi_toolbox.cache.documentation_path"));
+        return file_exists($this->config->get("openapi_toolbox.cache.documentation_path")) && file_exists($this->config->get("openapi_toolbox.cache.checksum_path"));
     }
 
     protected function getCachedDocumentation(): string
@@ -34,7 +34,8 @@ trait CacheActions
 
     protected function cacheChecksumIsValid(): bool
     {
-        $md5checksum = file_get_contents($this->config->get("openapi_toolbox.cache.checksum_path"));
+        $path = $this->config->get("openapi_toolbox.cache.checksum_path");
+        $md5checksum = shell_exec("md5sum -c $path");
 
         return count(
             array_filter(
@@ -50,6 +51,6 @@ trait CacheActions
 
         $documentationPath = $this->config->get("openapi_toolbox.specification.path");
         $checksumPath = $this->config->get("openapi_toolbox.cache.checksum_path");
-        shell_exec("find $documentationPath -exec md5sum {} \; > $checksumPath");
+        shell_exec("find $documentationPath -type f -exec md5sum {} \; > $checksumPath");
     }
 }

--- a/src/OpenApiSpecification/DocumentationBuilders/CacheActions.php
+++ b/src/OpenApiSpecification/DocumentationBuilders/CacheActions.php
@@ -37,11 +37,11 @@ trait CacheActions
         $md5checksum = $process->getOutput();
 
         return count(
-                array_filter(
-                    explode("\n", $md5checksum),
-                    fn(string $line): bool => str_ends_with($line, ": FAILED"),
-                ),
-            ) === 0;
+            array_filter(
+                explode("\n", $md5checksum),
+                fn(string $line): bool => str_ends_with($line, ": FAILED"),
+            ),
+        ) === 0;
     }
 
     protected function getCachedDocumentation(): string

--- a/src/OpenApiSpecification/DocumentationBuilders/CachedMultipleFilesDocumentationBuilder.php
+++ b/src/OpenApiSpecification/DocumentationBuilders/CachedMultipleFilesDocumentationBuilder.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blumilk\OpenApiToolbox\OpenApiSpecification\DocumentationBuilders;
+
+use KrzysztofRewak\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
+
+class CachedMultipleFilesDocumentationBuilder extends MultipleFilesDocumentationBuilder
+{
+    /**
+     * @throws InvalidFileTypeException
+     */
+    public function build(): string
+    {
+        if ($this->cachedDocumentationExists()) {
+            if ($this->cacheChecksumIsValid()) {
+                return $this->getCachedDocumentation();
+            }
+        }
+
+        $content = parent::build();
+        $this->cacheDocumentation($content);
+
+        return $content;
+    }
+
+    protected function cachedDocumentationExists(): bool
+    {
+        return file_exists($this->config->get("openapi_toolbox.cache.documentation_path"));
+    }
+
+    protected function getCachedDocumentation(): string
+    {
+        return file_get_contents($this->config->get("openapi_toolbox.cache.documentation_path"));
+    }
+
+    protected function cacheChecksumIsValid(): bool
+    {
+        $md5checksum = file_get_contents($this->config->get("openapi_toolbox.cache.checksum_path"));
+
+        return count(
+            array_filter(
+                explode("\n", $md5checksum),
+                fn(string $line): bool => str_ends_with($line, ": FAILED"),
+            ),
+        ) === 0;
+    }
+
+    protected function cacheDocumentation(string $content): void
+    {
+        file_put_contents($this->config->get("openapi_toolbox.cache.documentation_path"), $content);
+
+        $documentationPath = $this->config->get("openapi_toolbox.specification.path");
+        $checksumPath = $this->config->get("openapi_toolbox.cache.checksum_path");
+        shell_exec("find $documentationPath -exec md5sum {} \; > $checksumPath");
+    }
+}

--- a/src/OpenApiSpecification/DocumentationBuilders/CachedSingleFileDocumentationBuilder.php
+++ b/src/OpenApiSpecification/DocumentationBuilders/CachedSingleFileDocumentationBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Blumilk\OpenApiToolbox\OpenApiSpecification\DocumentationBuilders;
 
-class CachedMultipleFilesDocumentationBuilder extends MultipleFilesDocumentationBuilder
+class CachedSingleFileDocumentationBuilder extends SingleFileDocumentationBuilder
 {
     use CacheActions;
 

--- a/src/OpenApiSpecification/DocumentationBuilders/SingleFileDocumentationBuilder.php
+++ b/src/OpenApiSpecification/DocumentationBuilders/SingleFileDocumentationBuilder.php
@@ -11,7 +11,8 @@ class SingleFileDocumentationBuilder implements DocumentationBuilder
 {
     protected ConfigHelper $configHelper;
 
-    public function __construct(Repository $config) {
+    public function __construct(Repository $config)
+    {
         $this->configHelper = new ConfigHelper($config);
     }
 

--- a/src/OpenApiValidation/Commands/ValidateDocumentationFiles.php
+++ b/src/OpenApiValidation/Commands/ValidateDocumentationFiles.php
@@ -24,10 +24,12 @@ class ValidateDocumentationFiles extends Command
             $validator->validate();
         } catch (DocumentationFilesInvalidException $exception) {
             $this->error($exception->getMessage());
+
             return BaseCommand::FAILURE;
         }
 
         $this->info("OpenAPI specification is formatted properly.");
+
         return BaseCommand::SUCCESS;
     }
 }

--- a/tests/OpenApiCompatibilityTest.php
+++ b/tests/OpenApiCompatibilityTest.php
@@ -6,6 +6,7 @@ namespace Blumilk\OpenApiToolbox\Tests;
 
 use Blumilk\OpenApiToolbox\Config\Format;
 use Blumilk\OpenApiToolbox\OpenApiSpecification\SpecificationBuilder;
+use cebe\openapi\exceptions\UnresolvableReferenceException;
 use Illuminate\Config\Repository;
 use KrzysztofRewak\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
 use PHPUnit\Framework\Assert;
@@ -15,6 +16,7 @@ class OpenApiCompatibilityTest extends TestCase
 {
     /**
      * @throws InvalidFileTypeException
+     * @throws UnresolvableReferenceException
      */
     public function testSingleFileDocumentationBuild(): void
     {
@@ -32,6 +34,7 @@ class OpenApiCompatibilityTest extends TestCase
 
     /**
      * @throws InvalidFileTypeException
+     * @throws UnresolvableReferenceException
      */
     public function testMultipleFilesDocumentationWithSingleFileConfigurationBuild(): void
     {
@@ -50,6 +53,7 @@ class OpenApiCompatibilityTest extends TestCase
 
     /**
      * @throws InvalidFileTypeException
+     * @throws UnresolvableReferenceException
      */
     public function testMultipleFilesDocumentationBuild(): void
     {

--- a/tests/OpenApiValidationTest.php
+++ b/tests/OpenApiValidationTest.php
@@ -26,6 +26,7 @@ class OpenApiValidationTest extends TestCase
         $validator = new DocumentationFilesValidator($builder);
 
         $exceptions = [];
+
         try {
             $validator->validate();
         } catch (Throwable $e) {
@@ -47,6 +48,7 @@ class OpenApiValidationTest extends TestCase
         $validator = new DocumentationFilesValidator($builder);
 
         $exceptions = [];
+
         try {
             $validator->validate();
         } catch (Throwable $e) {
@@ -68,6 +70,7 @@ class OpenApiValidationTest extends TestCase
         $validator = new DocumentationFilesValidator($builder);
 
         $exceptions = [];
+
         try {
             $validator->validate();
         } catch (Throwable $e) {
@@ -92,6 +95,7 @@ class OpenApiValidationTest extends TestCase
         $validator = new DocumentationFilesValidator($builder);
 
         $exceptions = [];
+
         try {
             $validator->validate();
         } catch (Throwable $e) {


### PR DESCRIPTION
This PR adds a feature to cache multiple files documentation output to increase retrieving speed. It should be nice mostly for testing.

Also:
* codestyle was bumped and ran with new common ruleset