### PR TITLE
#11 - single file UI source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
   "scripts": {
     "cs": "./vendor/bin/php-cs-fixer fix --dry-run --diff --config codestyle.php",
     "csf": "./vendor/bin/php-cs-fixer fix --diff --config codestyle.php",
-    "test": "./vendor/bin/phpunit tests --colors always"
+    "test": "./vendor/bin/phpunit tests --colors"
   },
   "config": {
     "sort-packages": true

--- a/config/openapi_toolbox.php
+++ b/config/openapi_toolbox.php
@@ -19,6 +19,7 @@ return [
     ],
     "ui" => [
         "enabled" => false,
+        "single_source" => false,
         "title" => "Documentation",
         "routing" => [
             "prefix" => "documentation",

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@ return [
     ],
     "ui" => [
         "enabled" => false,
+        "single_source" => false,
         "title" => "Documentation",
         "routing" => [
             "prefix" => "documentation",
@@ -81,6 +82,8 @@ return [
 With configuration `openapi_toolbox.ui.enabled = true` a documentation UI will be built from configurable path and served on configurable route. Currently, the [Stoplight Elements](https://stoplight.io/open-source/elements) and [Swagger UI](https://swagger.io/tools/swagger-ui/) are only available UI base components configurable by `openapi_toolbox.ui.provider` setting.
 
 By default, it should be available under `GET /documentation`.
+
+By changing configuration variable `openapi_toolbox.ui.single_source` to `true`, application will serve already built single source file for GUI.
 
 #### OpenAPI documentation endpoint
 

--- a/src/DocumentationUI/Http/DocumentationUIController.php
+++ b/src/DocumentationUI/Http/DocumentationUIController.php
@@ -21,10 +21,14 @@ class DocumentationUIController
 {
     public function index(Repository $config, UrlGeneratorContract $url, Factory $view): View
     {
-        $route = $url->route(
-            name: $config->get("openapi_toolbox.ui.routing.name") . ".file",
-            parameters: $config->get("openapi_toolbox.specification.index"),
-        );
+        $route = !$config->get("openapi_toolbox.ui.single_source", false)
+            ? $url->route(
+                name: $config->get("openapi_toolbox.ui.routing.name", "documentation") . ".file",
+                parameters: $config->get("openapi_toolbox.specification.index", "openapi.yml"),
+            )
+            : $url->route(
+                name: $config->get("openapi_toolbox.ui.routing.name", "documentation") . ".raw",
+            );
 
         $template = match ($config->get("openapi_toolbox.ui.provider")) {
             UIProvider::Swagger => "swagger",


### PR DESCRIPTION
With this PR you are going to be able to change behaviour of fetching OpenAPI documentation source. By default - when it's built from multiple files - it's served as multiple source files. It could generate problems with throttling.

Now, with `openapi_toolbox.ui.single_source` set to `true`, it will be served as one file.