### PR TITLE
#34 - dependencies update fix

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [ "8.2" ]
+        php: [ "8.3" ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 composer.lock
 .env
 .toolbox.cache
+.php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/blumilksoftware/openapi-toolbox",
   "license": "MIT",
   "require": {
-    "php": "^8.2",
+    "php": "^8.3",
     "illuminate/config": "^11.0",
     "illuminate/console": "^11.0",
     "illuminate/http": "^11.0",

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
   "license": "MIT",
   "require": {
     "php": "^8.2",
-    "illuminate/config": "^10.11|^11.0",
-    "illuminate/console": "^10.11|^11.0",
-    "illuminate/http": "^10.11|^11.0",
-    "illuminate/support": "^10.11|^11.0",
-    "kirschbaum-development/laravel-openapi-validator": "^0.3|^1.0",
+    "illuminate/config": "^11.0",
+    "illuminate/console": "^11.0",
+    "illuminate/http": "^11.0",
+    "illuminate/support": "^11.0",
+    "kirschbaum-development/laravel-openapi-validator": "^1.0",
     "krzysztofrewak/openapi-merge": "^2.1"
   },
   "require-dev": {
-    "blumilksoftware/codestyle": "^3.0",
+    "blumilksoftware/codestyle": "^4.0",
     "phpunit/phpunit": "^11.1"
   },
   "autoload": {

--- a/src/OpenApiCompatibility/OpenApiCompatibility.php
+++ b/src/OpenApiCompatibility/OpenApiCompatibility.php
@@ -6,12 +6,37 @@ namespace Blumilk\OpenApiToolbox\OpenApiCompatibility;
 
 use Blumilk\OpenApiToolbox\OpenApiSpecification\SpecificationBuilder;
 use Illuminate\Contracts\Config\Repository;
+use Kirschbaum\OpenApiValidator\Exceptions\UnknownParserForFileTypeException;
+use Kirschbaum\OpenApiValidator\Exceptions\UnknownSpecFileTypeException;
 use Kirschbaum\OpenApiValidator\ValidatesOpenApiSpec;
 use KrzysztofRewak\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
+use League\OpenAPIValidation\PSR7\ValidatorBuilder;
 
 trait OpenApiCompatibility
 {
     use ValidatesOpenApiSpec;
+
+    /**
+     * @throws InvalidFileTypeException
+     * @throws UnknownParserForFileTypeException
+     * @throws UnknownSpecFileTypeException
+     */
+    public function getOpenApiValidatorBuilder(): ValidatorBuilder
+    {
+        if (!isset($this->openApiValidatorBuilder)) {
+            $specType = $this->getSpecFileType();
+
+            if ($specType === "json") {
+                $this->openApiValidatorBuilder = (new ValidatorBuilder())->fromJson($this->getOpenApiSpec());
+            } elseif ($specType === "yaml") {
+                $this->openApiValidatorBuilder = (new ValidatorBuilder())->fromYaml($this->getOpenApiSpec());
+            } else {
+                throw new UnknownParserForFileTypeException("Unknown parser for file type {$specType}");
+            }
+        }
+
+        return $this->openApiValidatorBuilder;
+    }
 
     /**
      * @throws InvalidFileTypeException


### PR DESCRIPTION
New version of `kirschbaum-development/laravel-openapi-validator` breaks project, as it requires path to the file instead of content of its. This PR should fix it and close #34.

Also: I dropped support for Laravel 10.