### PR TITLE
#36 - abandon custom dependencies in core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,13 @@
     "illuminate/console": "^11.0",
     "illuminate/http": "^11.0",
     "illuminate/support": "^11.0",
+    "illuminate/testing": "^11.34",
     "kirschbaum-development/laravel-openapi-validator": "^1.0",
-    "krzysztofrewak/openapi-merge": "^2.1"
+    "marcelthole/openapi-merge": "^2.3"
   },
   "require-dev": {
     "blumilksoftware/codestyle": "^4.0",
+    "orchestra/testbench": "^9.6",
     "phpunit/phpunit": "^11.1"
   },
   "autoload": {

--- a/src/DocumentationUI/Http/DocumentationUIController.php
+++ b/src/DocumentationUI/Http/DocumentationUIController.php
@@ -14,7 +14,7 @@ use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\JsonResponse;
-use KrzysztofRewak\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
+use Mthole\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Yaml\Yaml;
 

--- a/src/OpenApiCompatibility/OpenApiCompatibility.php
+++ b/src/OpenApiCompatibility/OpenApiCompatibility.php
@@ -59,7 +59,10 @@ trait OpenApiCompatibility
 
     protected function getSpecFileType(): string
     {
-        return strtolower($this->getDocumentationConfig()->getFormat()->name);
+        return match (true) {
+            $this->getDocumentationConfig()->getFormat()->isYml() => "yaml",
+            default => "json",
+        };
     }
 
     /**

--- a/src/OpenApiCompatibility/OpenApiCompatibility.php
+++ b/src/OpenApiCompatibility/OpenApiCompatibility.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Blumilk\OpenApiToolbox\OpenApiCompatibility;
 
 use Blumilk\OpenApiToolbox\Config\DocumentationConfig;
+use Blumilk\OpenApiToolbox\Config\Format;
 use Blumilk\OpenApiToolbox\OpenApiSpecification\SpecificationBuilder;
 use Illuminate\Contracts\Config\Repository;
 use Kirschbaum\OpenApiValidator\Exceptions\UnknownParserForFileTypeException;
@@ -60,8 +61,8 @@ trait OpenApiCompatibility
     protected function getSpecFileType(): string
     {
         return match (true) {
-            $this->getDocumentationConfig()->getFormat()->isYml() => "yaml",
-            default => "json",
+            $this->getDocumentationConfig()->getFormat() === Format::Json => "json",
+            default => "yaml",
         };
     }
 

--- a/src/OpenApiCompatibility/OpenApiCompatibility.php
+++ b/src/OpenApiCompatibility/OpenApiCompatibility.php
@@ -39,12 +39,9 @@ trait OpenApiCompatibility
         return $this->openApiValidatorBuilder;
     }
 
-    public function getDocumentationName(): string
+    protected function getSpecFileType(): string
     {
-        /** @var Repository $config */
-        $config = app("config");
-
-        return $config->get("openapi_toolbox.default");
+        return strtolower($this->getDocumentationConfig()->getFormat()->name);
     }
 
     public function getDocumentationConfig(): DocumentationConfig
@@ -55,6 +52,14 @@ trait OpenApiCompatibility
         $name = $this->getDocumentationName();
 
         return new DocumentationConfig($config->get("openapi_toolbox.documentations.$name"));
+    }
+
+    public function getDocumentationName(): string
+    {
+        /** @var Repository $config */
+        $config = app("config");
+
+        return $config->get("openapi_toolbox.default");
     }
 
     /**

--- a/src/OpenApiCompatibility/OpenApiCompatibility.php
+++ b/src/OpenApiCompatibility/OpenApiCompatibility.php
@@ -10,8 +10,8 @@ use Illuminate\Contracts\Config\Repository;
 use Kirschbaum\OpenApiValidator\Exceptions\UnknownParserForFileTypeException;
 use Kirschbaum\OpenApiValidator\Exceptions\UnknownSpecFileTypeException;
 use Kirschbaum\OpenApiValidator\ValidatesOpenApiSpec;
-use KrzysztofRewak\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
 use League\OpenAPIValidation\PSR7\ValidatorBuilder;
+use Mthole\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
 
 trait OpenApiCompatibility
 {

--- a/src/OpenApiCompatibility/OpenApiCompatibility.php
+++ b/src/OpenApiCompatibility/OpenApiCompatibility.php
@@ -39,11 +39,6 @@ trait OpenApiCompatibility
         return $this->openApiValidatorBuilder;
     }
 
-    protected function getSpecFileType(): string
-    {
-        return strtolower($this->getDocumentationConfig()->getFormat()->name);
-    }
-
     public function getDocumentationConfig(): DocumentationConfig
     {
         /** @var Repository $config */
@@ -60,6 +55,11 @@ trait OpenApiCompatibility
         $config = app("config");
 
         return $config->get("openapi_toolbox.default");
+    }
+
+    protected function getSpecFileType(): string
+    {
+        return strtolower($this->getDocumentationConfig()->getFormat()->name);
     }
 
     /**

--- a/src/OpenApiSpecification/DocumentationBuilders/MultipleFilesDocumentationBuilder.php
+++ b/src/OpenApiSpecification/DocumentationBuilders/MultipleFilesDocumentationBuilder.php
@@ -6,11 +6,14 @@ namespace Blumilk\OpenApiToolbox\OpenApiSpecification\DocumentationBuilders;
 
 use Blumilk\OpenApiToolbox\Config\DocumentationConfig;
 use Blumilk\OpenApiToolbox\Config\Format;
-use KrzysztofRewak\OpenApiMerge\FileHandling\File;
-use KrzysztofRewak\OpenApiMerge\OpenApiMerge;
-use KrzysztofRewak\OpenApiMerge\Reader\FileReader;
-use KrzysztofRewak\OpenApiMerge\Writer\DefinitionWriter;
-use KrzysztofRewak\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
+use Mthole\OpenApiMerge\FileHandling\File;
+use Mthole\OpenApiMerge\Merge\ComponentsMerger;
+use Mthole\OpenApiMerge\Merge\ReferenceNormalizer;
+use Mthole\OpenApiMerge\Merge\SecurityPathMerger;
+use Mthole\OpenApiMerge\OpenApiMerge;
+use Mthole\OpenApiMerge\Reader\FileReader;
+use Mthole\OpenApiMerge\Writer\DefinitionWriter;
+use Mthole\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
 
 class MultipleFilesDocumentationBuilder implements DocumentationBuilder
 {
@@ -23,10 +26,18 @@ class MultipleFilesDocumentationBuilder implements DocumentationBuilder
      */
     public function build(): string
     {
-        $merger = new OpenApiMerge(new FileReader());
+        $merger = new OpenApiMerge(
+            new FileReader(),
+            [
+                new ComponentsMerger(),
+                new SecurityPathMerger(),
+            ],
+            new ReferenceNormalizer(),
+        );
+
         $mergedResult = $merger->mergeFiles(
             new File($this->config->getIndexPath()),
-            ...array_map(
+            array_map(
                 static fn(string $file): File => new File($file),
                 glob($this->getDocumentationFilesPathPattern()),
             ),

--- a/src/OpenApiSpecification/SpecificationBuilder.php
+++ b/src/OpenApiSpecification/SpecificationBuilder.php
@@ -9,7 +9,7 @@ use Blumilk\OpenApiToolbox\OpenApiSpecification\DocumentationBuilders\CachedMult
 use Blumilk\OpenApiToolbox\OpenApiSpecification\DocumentationBuilders\CachedSingleFileDocumentationBuilder;
 use Blumilk\OpenApiToolbox\OpenApiSpecification\DocumentationBuilders\MultipleFilesDocumentationBuilder;
 use Blumilk\OpenApiToolbox\OpenApiSpecification\DocumentationBuilders\SingleFileDocumentationBuilder;
-use KrzysztofRewak\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
+use Mthole\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
 
 class SpecificationBuilder
 {

--- a/src/OpenApiValidation/Commands/ValidateDocumentationFiles.php
+++ b/src/OpenApiValidation/Commands/ValidateDocumentationFiles.php
@@ -11,7 +11,7 @@ use Blumilk\OpenApiToolbox\OpenApiValidation\DocumentationFilesInvalidException;
 use Blumilk\OpenApiToolbox\OpenApiValidation\DocumentationFilesValidator;
 use Illuminate\Config\Repository;
 use Illuminate\Console\Command;
-use KrzysztofRewak\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
+use Mthole\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
 use Symfony\Component\Console\Command\Command as BaseCommand;
 
 class ValidateDocumentationFiles extends Command

--- a/src/OpenApiValidation/DocumentationFilesValidator.php
+++ b/src/OpenApiValidation/DocumentationFilesValidator.php
@@ -6,7 +6,7 @@ namespace Blumilk\OpenApiToolbox\OpenApiValidation;
 
 use Blumilk\OpenApiToolbox\OpenApiSpecification\SpecificationBuilder;
 use cebe\openapi\exceptions\UnresolvableReferenceException;
-use KrzysztofRewak\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
+use Mthole\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
 use Symfony\Component\Yaml\Exception\ParseException;
 use TypeError;
 

--- a/tests/OpenApiBuilderTest.php
+++ b/tests/OpenApiBuilderTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blumilk\OpenApiToolbox\Tests;
+
+use Blumilk\OpenApiToolbox\Config\DocumentationConfig;
+use Blumilk\OpenApiToolbox\Config\Format;
+use Blumilk\OpenApiToolbox\OpenApiSpecification\SpecificationBuilder;
+use Mthole\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class OpenApiBuilderTest extends TestCase
+{
+    /**
+     * @throws InvalidFileTypeException
+     */
+    public function testSingleFileDocumentationBuild(): void
+    {
+        $config = new DocumentationConfig([
+            "specification" => [
+                "index" => "openapi.yml",
+                "path" => realpath(__DIR__ . "/mocks/yml/singleFileDocumentation"),
+                "allow_multiple_files" => false,
+            ],
+            "format" => Format::Yml,
+        ]);
+
+        $builder = new SpecificationBuilder($config);
+        $result = $builder->build();
+
+        Assert::assertStringContainsString("API Documentation", $result);
+    }
+
+    /**
+     * @throws InvalidFileTypeException
+     */
+    public function testMultipleFilesDocumentationWithSingleFileConfigurationBuild(): void
+    {
+        $config = new DocumentationConfig([
+            "specification" => [
+                "index" => "openapi.yml",
+                "path" => realpath(__DIR__ . "/mocks/yml/multipleFilesDocumentation"),
+                "allow_multiple_files" => false,
+            ],
+            "format" => Format::Yml,
+        ]);
+
+        $builder = new SpecificationBuilder($config);
+        $result = $builder->build();
+
+        Assert::assertStringContainsString("API Documentation", $result);
+        Assert::assertStringNotContainsString("Ping endpoint", $result);
+    }
+
+    /**
+     * @throws InvalidFileTypeException
+     */
+    public function testMultipleFilesDocumentationBuild(): void
+    {
+        $config = new DocumentationConfig([
+            "specification" => [
+                "index" => "openapi.yml",
+                "path" => realpath(__DIR__ . "/mocks/yml/multipleFilesDocumentation"),
+                "allow_multiple_files" => true,
+            ],
+            "format" => Format::Yml,
+        ]);
+
+        $builder = new SpecificationBuilder($config);
+        $result = $builder->build();
+
+        Assert::assertStringContainsString("API Documentation", $result);
+        Assert::assertStringContainsString("Ping endpoint", $result);
+    }
+}

--- a/tests/OpenApiCompatibilityTest.php
+++ b/tests/OpenApiCompatibilityTest.php
@@ -6,72 +6,27 @@ namespace Blumilk\OpenApiToolbox\Tests;
 
 use Blumilk\OpenApiToolbox\Config\DocumentationConfig;
 use Blumilk\OpenApiToolbox\Config\Format;
-use Blumilk\OpenApiToolbox\OpenApiSpecification\SpecificationBuilder;
-use KrzysztofRewak\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
-use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\TestCase;
+use Blumilk\OpenApiToolbox\OpenApiCompatibility\OpenApiCompatibility;
+use Orchestra\Testbench\TestCase;
 
 class OpenApiCompatibilityTest extends TestCase
 {
-    /**
-     * @throws InvalidFileTypeException
-     */
-    public function testSingleFileDocumentationBuild(): void
+    use OpenApiCompatibility;
+
+    public function getDocumentationConfig(): DocumentationConfig
     {
-        $config = new DocumentationConfig([
+        return new DocumentationConfig([
             "specification" => [
                 "index" => "openapi.yml",
-                "path" => realpath(__DIR__ . "/mocks/yml/singleFileDocumentation"),
+                "path" => realpath(__DIR__ . "/mocks/yml/loginDocumentation"),
                 "allow_multiple_files" => false,
             ],
-            "format" => Format::Yml,
+            "format" => Format::Yaml,
         ]);
-
-        $builder = new SpecificationBuilder($config);
-        $result = $builder->build();
-
-        Assert::assertStringContainsString("API Documentation", $result);
     }
 
-    /**
-     * @throws InvalidFileTypeException
-     */
-    public function testMultipleFilesDocumentationWithSingleFileConfigurationBuild(): void
+    public function testDocumentationCompatibility(): void
     {
-        $config = new DocumentationConfig([
-            "specification" => [
-                "index" => "openapi.yml",
-                "path" => realpath(__DIR__ . "/mocks/yml/multipleFilesDocumentation"),
-                "allow_multiple_files" => false,
-            ],
-            "format" => Format::Yml,
-        ]);
-
-        $builder = new SpecificationBuilder($config);
-        $result = $builder->build();
-
-        Assert::assertStringContainsString("API Documentation", $result);
-        Assert::assertStringNotContainsString("Ping endpoint", $result);
-    }
-
-    /**
-     * @throws InvalidFileTypeException
-     */
-    public function testMultipleFilesDocumentationBuild(): void
-    {
-        $config = new DocumentationConfig([
-            "specification" => [
-                "index" => "openapi.yml",
-                "path" => realpath(__DIR__ . "/mocks/yml/multipleFilesDocumentation"),
-                "allow_multiple_files" => true,
-            ],
-            "format" => Format::Yml,
-        ]);
-
-        $builder = new SpecificationBuilder($config);
-        $result = $builder->build();
-
-        Assert::assertStringContainsString("API Documentation", $result);
-        Assert::assertStringContainsString("Ping endpoint", $result);
+        $this->postJson("login");
     }
 }

--- a/tests/OpenApiCompatibilityTest.php
+++ b/tests/OpenApiCompatibilityTest.php
@@ -27,6 +27,6 @@ class OpenApiCompatibilityTest extends TestCase
 
     public function testDocumentationCompatibility(): void
     {
-        $this->postJson("login");
+        $this->postJson("login", ["password" => "password"]);
     }
 }

--- a/tests/OpenApiCompatibilityTest.php
+++ b/tests/OpenApiCompatibilityTest.php
@@ -27,6 +27,12 @@ class OpenApiCompatibilityTest extends TestCase
 
     public function testDocumentationCompatibility(): void
     {
-        $this->postJson("login", ["password" => "password"]);
+        $response = $this->postJson("login", ["email" => "example@example.com", "password" => "password"]);
+        $response->assertOk();
+    }
+
+    protected function defineRoutes($router): void
+    {
+        $router->post("login", fn() => ["status" => true]);
     }
 }

--- a/tests/OpenApiIncompatibilityTest.php
+++ b/tests/OpenApiIncompatibilityTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blumilk\OpenApiToolbox\Tests;
+
+use Kirschbaum\OpenApiValidator\Exceptions\UnknownParserForFileTypeException;
+use Kirschbaum\OpenApiValidator\Exceptions\UnknownSpecFileTypeException;
+use League\OpenAPIValidation\PSR7\Exception\Validation\AddressValidationFailed;
+use League\OpenAPIValidation\PSR7\Exception\ValidationFailed;
+use League\OpenAPIValidation\PSR7\OperationAddress;
+use Mthole\OpenApiMerge\Writer\Exception\InvalidFileTypeException;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+class OpenApiIncompatibilityTest extends OpenApiCompatibilityTest
+{
+    protected bool $failed = false;
+
+    public function testDocumentationIncompatibility(): void
+    {
+        $this->postJson("login", ["email" => "example@example.com", "password" => "password"]);
+        $this->assertTrue($this->failed);
+    }
+
+    protected function defineRoutes($router): void
+    {
+        $router->post("login", fn() => ["message" => "Unexpected message."]);
+    }
+
+    /**
+     * @throws InvalidFileTypeException
+     * @throws UnknownParserForFileTypeException
+     * @throws UnknownSpecFileTypeException
+     * @throws ValidationFailed
+     */
+    protected function validateResponse(OperationAddress $address, SymfonyResponse $response): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $psr = new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
+
+        try {
+            $this->getOpenApiValidatorBuilder()
+                ->getResponseValidator()
+                ->validate(
+                    $address,
+                    $psr->createResponse($response),
+                );
+        } catch (AddressValidationFailed) {
+            $this->failed = true;
+        }
+    }
+}

--- a/tests/mocks/yml/loginDocumentation/openapi.yml
+++ b/tests/mocks/yml/loginDocumentation/openapi.yml
@@ -1,0 +1,60 @@
+openapi: 3.1.0
+info:
+  title: application
+  version: 0.0.1
+  description: "API Documentation"
+  contact:
+    name: Blumilk development team
+    email: office@blumilk.pl
+    url: blumilk.pl
+servers:
+  - url: https://application-backend.blumilk.localhost/api/
+    description: Development server
+tags:
+  - name: Info
+    description: Routes accessible for all users
+paths:
+  "/login":
+    get:
+      tags:
+        - Authentication
+      summary: Authentication endpoint
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                  examples:
+                    - user@example.com
+                password:
+                  type: string
+                  examples:
+                    - password!123+X%
+              additionalProperties: false
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: boolean
+                    example: true
+        '401':
+          description: Not Authorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: boolean
+                    example: false

--- a/tests/mocks/yml/loginDocumentation/openapi.yml
+++ b/tests/mocks/yml/loginDocumentation/openapi.yml
@@ -8,7 +8,7 @@ info:
     email: office@blumilk.pl
     url: blumilk.pl
 servers:
-  - url: https://application-backend.blumilk.localhost/api/
+  - url: https://application-backend.blumilk.localhost/
     description: Development server
 tags:
   - name: Info
@@ -48,6 +48,7 @@ paths:
                   status:
                     type: boolean
                     example: true
+                additionalProperties: false
         '401':
           description: Not Authorized
           content:
@@ -58,3 +59,4 @@ paths:
                   status:
                     type: boolean
                     example: false
+                additionalProperties: false

--- a/tests/mocks/yml/loginDocumentation/openapi.yml
+++ b/tests/mocks/yml/loginDocumentation/openapi.yml
@@ -15,7 +15,7 @@ tags:
     description: Routes accessible for all users
 paths:
   "/login":
-    get:
+    post:
       tags:
         - Authentication
       summary: Authentication endpoint


### PR DESCRIPTION
This should close #36 and free this package from custom dependencies. Most important is change from forked `krzysztofrewak/openapi-merge` to the original and supported `marcelthole/openapi-merge`.

I also added some tests for OpenApiCompatibility trait for PHPUnit.